### PR TITLE
bootloader: tests: Fix matching regex for new Twister version

### DIFF
--- a/tests/subsys/bootloader/bl_validation_neg/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation_neg/testcase.yaml
@@ -11,7 +11,7 @@ tests:
       type: multi_line
       ordered: true
       regex:
-        - "Running test suite test_bl_validation_neg"
+        - "Running TESTSUITE test_bl_validation_neg"
         - "Rebooting. Should fail to validate slot 1."
         - "Attempting to boot slot 1."
         - "Firmware info doesn't point to itself."
@@ -37,7 +37,7 @@ tests:
       type: multi_line
       ordered: true
       regex:
-        - "Running test suite test_bl_validation_neg"
+        - "Running TESTSUITE test_bl_validation_neg"
         - "Rebooting. Should fail to validate slot 1."
         - "Attempting to boot slot 1."
         - "Firmware info doesn't point to itself."


### PR DESCRIPTION
The new version of twister has a different printout for running on a
test suite, For bootloader.bl_validation.negative, that is used to verify
that the right code is running on the device, so it should also be
updated in the test case spec

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>